### PR TITLE
Add changelog action

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -1,0 +1,20 @@
+name: Changelog
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Check Changelog Update
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Changelog check
+        uses: Zomzog/changelog-checker@v1.0.0
+        with:
+          fileName: CHANGELOG.md # default `CHANGELOG.adoc`
+          noChangelogLabel: my custom label # default `no changelog`
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.1]
+
+### Added
+
+- GitHub Action for checking changelog updates
+
 ## [1.0.0]
 
 ### Added


### PR DESCRIPTION
This PR adds a GitHub action which checks that the changelog is updated on a PR to the *master* branch.

If not, the PR will fail and the action will add a comment to the PR.